### PR TITLE
Downgrading transformer

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -148,7 +148,7 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
-tokenizers==0.13.3
+tokenizers==0.15.2
     # via transformers
 tomli==2.0.1
     # via pytest

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -126,6 +126,8 @@ pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   transformers
+regex==2024.7.24
+    # via transformers
 requests==2.32.3
     # via
     #   huggingface-hub
@@ -136,6 +138,8 @@ requests-cache==1.2.1
     # via ml_services (setup.cfg)
 requests-mock==1.12.1
     # via ml_services (setup.cfg)
+safetensors==0.4.4
+    # via transformers
 scipy==1.13.1
     # via ml_services (setup.cfg)
 six==1.16.0
@@ -144,6 +148,8 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
+tokenizers==0.13.3
+    # via transformers
 tomli==2.0.1
     # via pytest
 torch==2.4.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -126,9 +126,7 @@ pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   transformers
-regex==2024.7.24
-    # via transformers
-requests==2.32.3
+equests==2.32.3
     # via
     #   huggingface-hub
     #   requests-cache
@@ -138,8 +136,6 @@ requests-cache==1.2.1
     # via ml_services (setup.cfg)
 requests-mock==1.12.1
     # via ml_services (setup.cfg)
-safetensors==0.4.4
-    # via transformers
 scipy==1.13.1
     # via ml_services (setup.cfg)
 six==1.16.0
@@ -148,8 +144,6 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
-tokenizers==0.13.3
-    # via transformers
 tomli==2.0.1
     # via pytest
 torch==2.4.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -148,7 +148,7 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
-tokenizers==0.19.1
+tokenizers==0.13.3
     # via transformers
 tomli==2.0.1
     # via pytest

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -158,7 +158,8 @@ tqdm==4.66.5
     # via
     #   huggingface-hub
     #   transformers
-transformers==4.44.1
+# Pinned because of compatability issues, https://github.com/huggingface/transformers/issues/30965
+transformers==4.37.0
     # via ml_services (setup.cfg)
 triton==3.0.0
     # via torch

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -126,7 +126,7 @@ pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   transformers
-equests==2.32.3
+requests==2.32.3
     # via
     #   huggingface-hub
     #   requests-cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,7 +129,7 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
-tokenizers==0.19.1
+tokenizers==0.13.3
     # via transformers
 torch==2.4.0
     # via ml_services (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -137,7 +137,8 @@ tqdm==4.66.5
     # via
     #   huggingface-hub
     #   transformers
-transformers==4.44.1
+# Pinned because of compatability issues, https://github.com/huggingface/transformers/issues/30965
+transformers==4.37.0
     # via ml_services (setup.cfg)
 triton==3.0.0
     # via torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,7 +129,7 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
-tokenizers==0.13.3
+tokenizers==0.15.2
     # via transformers
 torch==2.4.0
     # via ml_services (setup.cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,8 +110,6 @@ pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   transformers
-regex==2024.7.24
-    # via transformers
 requests==2.32.3
     # via
     #   huggingface-hub
@@ -119,8 +117,6 @@ requests==2.32.3
     #   transformers
 requests-cache==1.2.1
     # via ml_services (setup.cfg)
-safetensors==0.4.4
-    # via transformers
 scipy==1.13.1
     # via ml_services (setup.cfg)
 six==1.16.0
@@ -129,8 +125,6 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
-tokenizers==0.13.3
-    # via transformers
 torch==2.4.0
     # via ml_services (setup.cfg)
 tqdm==4.66.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,6 +110,8 @@ pyyaml==6.0.2
     # via
     #   huggingface-hub
     #   transformers
+regex==2024.7.24
+    # via transformers
 requests==2.32.3
     # via
     #   huggingface-hub
@@ -117,6 +119,8 @@ requests==2.32.3
     #   transformers
 requests-cache==1.2.1
     # via ml_services (setup.cfg)
+safetensors==0.4.4
+    # via transformers
 scipy==1.13.1
     # via ml_services (setup.cfg)
 six==1.16.0
@@ -125,6 +129,8 @@ six==1.16.0
     #   url-normalize
 sympy==1.13.2
     # via torch
+tokenizers==0.13.3
+    # via transformers
 torch==2.4.0
     # via ml_services (setup.cfg)
 tqdm==4.66.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,11 @@ url = https://github.com/uwcirg/isacc-ml
 [options]
 packages = ml_services
 python_requires = >=3.9
+
+# Pinned transformers because of compatability issues
+# https://github.com/huggingface/transformers/issues/30965
 install_requires =
+    transformers==4.37.0
     flask
     gunicorn
     requests-cache
@@ -16,7 +20,6 @@ install_requires =
     pandas
     scipy
     torch
-    transformers
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,12 @@ url = https://github.com/uwcirg/isacc-ml
 packages = ml_services
 python_requires = >=3.9
 
-# Pinned transformers because of compatability issues
+# Pinned transformers because of compatability issues 
+# Pinned tokenizers to comply with transformers
 # https://github.com/huggingface/transformers/issues/30965
 install_requires =
     transformers==4.37.0
+    tokenizers==0.15.2
     flask
     gunicorn
     requests-cache


### PR DESCRIPTION
Downgrading transformers to 4.37.0 to resolve dependencies conflict,
Pinned tokenizers  to 0.15.2 to comply with transformers


https://github.com/huggingface/transformers/issues/30965